### PR TITLE
Add load-elasticsearch-index to cli; Changes to mapping; Parameterize the ES version

### DIFF
--- a/tl/cli/build-elasticsearch-input.py
+++ b/tl/cli/build-elasticsearch-input.py
@@ -49,6 +49,13 @@ def add_arguments(parser):
     parser.add_argument('--output-file', action='store', dest='output_file_path', required=True,
                         help='output json lines file, to be loaded into ES')
 
+    parser.add_argument('--copy-to-properties', action='store', type=str, dest='copy_to_properties', default=None,
+                        help='''Name of the properties separated by comma which need to be added to all_labels in mapping file.
+                        Property Names supported by are: labels, aliases, descriptions, pagerank''')
+
+    parser.add_argument('--es-version', action='store', type=float, dest='es_version', default=7.9,
+                        help='Version of the Elasticsearch you are using')
+
 
 def run(**kwargs):
     from tl.utility.utility import Utility
@@ -61,7 +68,9 @@ def run(**kwargs):
                                          black_list_file_path=kwargs['blacklist_file_path'],
                                          extra_info=kwargs['extra_information'],
                                          description_properties=kwargs['description_properties'],
-                                         add_text=kwargs['add_text']
+                                         add_text=kwargs['add_text'],
+                                         copy_to_properties=kwargs['copy_to_properties'],
+                                         es_version=kwargs['es_version']
                                          )
     except:
         message = 'Command: build-elasticsearch-input\n'

--- a/tl/cli/load-elasticsearch-index.py
+++ b/tl/cli/load-elasticsearch-index.py
@@ -1,0 +1,55 @@
+import sys
+import argparse
+import traceback
+import tl.exceptions
+
+
+def parser():
+    return {
+        'help': 'loads a jsonlines file to Elasticsearch index.'
+    }
+
+
+def add_arguments(parser):
+    """
+    Parse Arguments
+    Args:
+        parser: (argparse.ArgumentParser)
+
+    """
+
+    parser.add_argument('--kgtk-jl-path', action='store',  dest='kgtk_jl_path',required=True,
+                       help='Path of the KGTK jsonlines file that needs to be loaded')
+    
+    parser.add_argument('--es-url', action='store', dest='es_url',required=True,
+                       help='Elasticsearch URL')
+
+    parser.add_argument('--es-index', action='store', dest='es_index',required=True,
+                       help='Name of the index')
+
+    parser.add_argument('--mapping-file-path', action='store', dest='mapping_file_path',default=None,
+                       help='Path of the mapping file')
+
+    parser.add_argument('--es-user', action='store', dest='es_user',default=None,
+                       help='Name of the elasticsearch index')
+
+    parser.add_argument('--es-pass', action='store', dest='es_pass',default=None,
+                       help='Password of elasticsearch index')
+
+    parser.add_argument('--es-version', action='store', type=float, dest='es_version', default=7.9,
+                        help='Version of the Elasticsearch you are using')
+
+
+def run(**kwargs):
+    from tl.utility.utility import Utility
+    try:
+        Utility.load_elasticsearch_index(kwargs['kgtk_jl_path'], kwargs['es_url'], kwargs['es_index'],
+                                         es_version=kwargs['es_version'],
+                                         mapping_file_path=kwargs['mapping_file_path'],
+                                         es_user=kwargs['es_user'],
+                                         es_pass=kwargs['es_pass'])
+    
+    except:
+        message = 'Command: load-elasticsearch-index\n'
+        message += 'Error Message: {}\n'.format(traceback.format_exc())
+        raise tl.exceptions.TLException(message)

--- a/tl/utility/utility.py
+++ b/tl/utility/utility.py
@@ -245,7 +245,7 @@ class Utility(object):
             return None
 
     @staticmethod
-    def create_mapping_es(es_version, str_fields_need_index: typing.List[str], float_fields: typing.List[str] = None, 
+    def create_mapping_es(es_version: float, str_fields_need_index: typing.List[str], float_fields: typing.List[str] = None, 
                           str_fields_no_index: typing.List[str] = None, copy_to_fields: typing.List[str] = None):
         properties_dict = {}
         # add property part


### PR DESCRIPTION
1. ElasticSearch version 6 onwards does not support mapping types in the mapping file. Added an es_version parameter to build-elasticsearch-input and load-elasticsearch-input cli commands. The version parameter would support the correct generation of the mapping file for the different versions. 

2. Parameterize the names of the properties that should have the copy_to parameter in the mapping file.

3. Added load-elasticsearch-index to cli.