### PR TITLE
Fix get kg links dropping rows

### DIFF
--- a/tl/features/get_kg_links.py
+++ b/tl/features/get_kg_links.py
@@ -21,11 +21,12 @@ def get_kg_links(score_column, file_path=None, df=None, label_column='label', to
         raise UnsupportTypeError("The input file is not a candidate file!")
 
     topk_df = df.groupby(['column', 'row']).apply(lambda x: x.sort_values([score_column], ascending=False)) \
-        .reset_index(drop=True).drop_duplicates(subset='kg_id')
+        .reset_index(drop=True)
 
     final_list = []
     grouped_obj = topk_df.groupby(['row', 'column'])
     for cell in grouped_obj:
+        cell[1].drop_duplicates(subset='kg_id',inplace=True)
         _ = {}
         _['column'] = cell[0][1]
         _['row'] = cell[0][0]


### PR DESCRIPTION
Quick Fix to have all rows after running `get-kg-links` command