### PR TITLE
Modified candidate generation to make it threaded

### DIFF
--- a/tl/candidate_generation/utility.py
+++ b/tl/candidate_generation/utility.py
@@ -2,6 +2,9 @@ import pandas as pd
 import sys
 from tl.file_formats_validator import FFV
 from tl.exceptions import UnsupportTypeError
+import concurrent.futures
+from concurrent.futures import ThreadPoolExecutor
+from itertools import repeat
 
 
 class Utility(object):
@@ -12,116 +15,93 @@ class Utility(object):
         self.ffv = FFV(previous_match_column_name)
         self.score_column_name = output_column_name
 
-    def create_candidates_df(self, df, column, size, properties, method, lower_case=True, auxiliary_fields=None,
-                             auxiliary_folder=None, auxiliary_file_prefix='', extra_musts: dict = None):
+    def create_candidates_df(self, df, column, size, properties, method,
+                             lower_case=False, auxiliary_fields=None,
+                             auxiliary_folder=None, auxiliary_file_prefix='',
+                             extra_musts: dict = None, max_threads=50):
         properties = [_.strip() for _ in properties.split(',')]
         candidates_format = list()
         df_columns = df.columns
         all_candidates_aux_dict = {}
+        rows = list()
+        relevant_columns = list()
+        max_threads = min(df.shape[0], max_threads)
 
         if self.ffv.is_canonical_file(df):
-            candidates_format, all_candidates_aux_dict = self.create_cfd_canonical(df, df_columns, column, size,
-                                                                                   properties, method, lower_case,
-                                                                                   auxiliary_fields=auxiliary_fields,
-                                                                                   extra_musts=extra_musts)
-
+            rows = df.to_dict("records")
+            with ThreadPoolExecutor(max_workers=max_threads) as executor:
+                for _candidates_format, candidates_aux_dict in executor.map(
+                            self.create_candidates, rows,
+                            repeat(df_columns), repeat(column),
+                            repeat(size), repeat(properties), repeat(method),
+                            repeat(lower_case),
+                            repeat(auxiliary_fields), repeat(extra_musts)):
+                    all_candidates_aux_dict = {
+                        **all_candidates_aux_dict,
+                        **candidates_aux_dict
+                        }
+                    candidates_format.extend(_candidates_format)
             self.write_auxiliary_files(auxiliary_folder,
                                        all_candidates_aux_dict,
                                        auxiliary_fields,
                                        prefix=auxiliary_file_prefix)
             return pd.DataFrame(candidates_format)
-
         elif self.ffv.is_candidates_file(df):
             grouped = df.groupby(by=['column', 'row', column])
             relevant_columns = [c for c in df_columns if
-                                c not in ['kg_id', 'kg_labels', 'method', 'kg_descriptions',
+                                c not in ['kg_id', 'kg_labels', 'method',
+                                          'kg_descriptions',
                                           self.previous_match_column_name]]
+            rows = list()
             for key_tuple, gdf in grouped:
                 gdf.reset_index(inplace=True)
-                tuple = ((c, gdf.at[0, c]) for c in relevant_columns)
-
-                _candidates_format, candidates_aux_dict = self.create_cfd_candidates(tuple, column, size,
-                                                                                     properties, method, lower_case,
-                                                                                     auxiliary_fields=auxiliary_fields,
-                                                                                     extra_musts=extra_musts)
-                all_candidates_aux_dict = {**all_candidates_aux_dict, **candidates_aux_dict}
-
-                candidates_format.extend(_candidates_format)
+                rows.append({c: gdf.at[0, c] for c in relevant_columns})
+            with ThreadPoolExecutor(max_workers=max_threads) as executor:
+                for _candidates_format, candidates_aux_dict in executor.map(
+                            self.create_candidates, rows,
+                            repeat(relevant_columns), repeat(column),
+                            repeat(size), repeat(properties), repeat(method),
+                            repeat(lower_case),
+                            repeat(auxiliary_fields), repeat(extra_musts)):
+                    all_candidates_aux_dict = {
+                        **all_candidates_aux_dict,
+                        **candidates_aux_dict
+                        }
+                    candidates_format.extend(_candidates_format)
             self.write_auxiliary_files(auxiliary_folder,
                                        all_candidates_aux_dict,
-                                       auxiliary_fields, prefix=auxiliary_file_prefix)
+                                       auxiliary_fields,
+                                       prefix=auxiliary_file_prefix)
             return pd.concat([df, pd.DataFrame(candidates_format)])
-
         else:
-            raise UnsupportTypeError("The input df is neither a canonical format or a candidate format!")
+            raise UnsupportTypeError(
+                "The input df is neither a canonical format"
+                " or a candidate format!"
+                )
 
-    def create_cfd_canonical(self, df, relevant_columns, column, size, properties, method, lower_case,
-                             auxiliary_fields=None, extra_musts=None):
-        candidates_format = list()
-        all_candidates_aux_dict = {}
-
-        for i, row in df.iterrows():
-            candidate_dict, candidate_aux_dict = self.es.search_term_candidates(row[column],
-                                                                                size,
-                                                                                properties,
-                                                                                method,
-                                                                                lower_case=lower_case,
-                                                                                auxiliary_fields=auxiliary_fields,
-                                                                                extra_musts=extra_musts)
-
-            all_candidates_aux_dict = {**all_candidates_aux_dict, **candidate_aux_dict}
-
-            if not candidate_dict:
-                cf_dict = {}
-                for key in relevant_columns:
-                    if key not in ['kg_id', 'kg_labels', 'method', self.score_column_name]:
-                        cf_dict[key] = row[key]
-
-                cf_dict['kg_id'] = ""
-                cf_dict['kg_labels'] = ""
-                cf_dict['kg_aliases'] = ""
-                cf_dict['method'] = method
-                cf_dict['kg_descriptions'] = ""
-                cf_dict['pagerank'] = 0.0
-                cf_dict[self.score_column_name] = 0.0
-                candidates_format.append(cf_dict)
-            else:
-                for kg_id in candidate_dict:
-                    cf_dict = {}
-                    for key in relevant_columns:
-                        if key not in ['kg_id', 'kg_labels', 'method', self.score_column_name]:
-                            cf_dict[key] = row[key]
-
-                    cf_dict['kg_id'] = kg_id
-                    cf_dict['kg_labels'] = candidate_dict[kg_id]['label_str']
-                    cf_dict['kg_aliases'] = candidate_dict[kg_id]['alias_str']
-                    cf_dict['method'] = method
-                    cf_dict['kg_descriptions'] = candidate_dict[kg_id]['description_str']
-                    cf_dict['pagerank'] = candidate_dict[kg_id]['pagerank_float']
-                    cf_dict[self.score_column_name] = candidate_dict[kg_id]['score']
-                    candidates_format.append(cf_dict)
-        return candidates_format, all_candidates_aux_dict
-
-    def create_cfd_candidates(self, key_tuple, column, size, properties, method, lower_case, auxiliary_fields=None,
-                              extra_musts=None):
+    def create_candidates(self, row, relevant_columns, column, size,
+                          properties, method, lower_case,
+                          auxiliary_fields=None,
+                          extra_musts=None):
         candidates_format = list()
 
         _ = {}
-        for k in key_tuple:
-            _[k[0]] = k[1]
+        for k in row:
+            _[k] = row[k]
 
-        candidate_dict, candidate_aux_dict = self.es.search_term_candidates(_[column],
-                                                                            size,
-                                                                            properties,
-                                                                            method,
-                                                                            lower_case=lower_case,
-                                                                            auxiliary_fields=auxiliary_fields,
-                                                                            extra_musts=extra_musts)
+        candidate_dict, candidate_aux_dict = self.es.search_term_candidates(
+                                            _[column],
+                                            size,
+                                            properties,
+                                            method,
+                                            lower_case=lower_case,
+                                            auxiliary_fields=auxiliary_fields,
+                                            extra_musts=extra_musts)
 
         if not candidate_dict:
             cf_dict = {}
 
-            for k in _:
+            for k in relevant_columns:
                 cf_dict[k] = _[k]
 
             cf_dict['kg_id'] = ""
@@ -135,20 +115,23 @@ class Utility(object):
         else:
             for kg_id in candidate_dict:
                 cf_dict = {}
-                for k in _:
+                for k in relevant_columns:
                     cf_dict[k] = _[k]
 
                 cf_dict['kg_id'] = kg_id
                 cf_dict['kg_labels'] = candidate_dict[kg_id]['label_str']
                 cf_dict['kg_aliases'] = candidate_dict[kg_id]['alias_str']
                 cf_dict['method'] = method
-                cf_dict['kg_descriptions'] = candidate_dict[kg_id]['description_str']
+                cf_dict['kg_descriptions'] = (candidate_dict[kg_id]
+                                              ['description_str'])
                 cf_dict['pagerank'] = candidate_dict[kg_id]['pagerank_float']
-                cf_dict[self.score_column_name] = candidate_dict[kg_id]['score']
+                cf_dict[self.score_column_name] = (candidate_dict[kg_id]
+                                                   ['score'])
                 candidates_format.append(cf_dict)
         return candidates_format, candidate_aux_dict
 
-    def write_auxiliary_files(self, auxiliary_folder, all_candidates_aux_dict, auxiliary_fields, prefix=''):
+    def write_auxiliary_files(self, auxiliary_folder, all_candidates_aux_dict,
+                              auxiliary_fields, prefix=''):
         _ = {}
         if auxiliary_fields is not None:
             for aux_field in auxiliary_fields:
@@ -169,4 +152,5 @@ class Utility(object):
             for key in _:
                 df = pd.DataFrame(_[key])
                 if len(df) > 0:
-                    df.to_csv(f"{auxiliary_folder}/{prefix}{key}.tsv", sep='\t', index=False)
+                    df.to_csv(f"{auxiliary_folder}/{prefix}{key}.tsv",
+                              sep='\t', index=False)

--- a/tl/candidate_generation/utility.py
+++ b/tl/candidate_generation/utility.py
@@ -1,8 +1,6 @@
 import pandas as pd
-import sys
 from tl.file_formats_validator import FFV
 from tl.exceptions import UnsupportTypeError
-import concurrent.futures
 from concurrent.futures import ThreadPoolExecutor
 from itertools import repeat
 
@@ -23,23 +21,18 @@ class Utility(object):
         candidates_format = list()
         df_columns = df.columns
         all_candidates_aux_dict = {}
-        rows = list()
-        relevant_columns = list()
         max_threads = min(df.shape[0], max_threads)
 
         if self.ffv.is_canonical_file(df):
             rows = df.to_dict("records")
             with ThreadPoolExecutor(max_workers=max_threads) as executor:
                 for _candidates_format, candidates_aux_dict in executor.map(
-                            self.create_candidates, rows,
-                            repeat(df_columns), repeat(column),
-                            repeat(size), repeat(properties), repeat(method),
-                            repeat(lower_case),
+                            self.create_candidates, rows, repeat(df_columns),
+                            repeat(column), repeat(size), repeat(properties),
+                            repeat(method), repeat(lower_case),
                             repeat(auxiliary_fields), repeat(extra_musts)):
-                    all_candidates_aux_dict = {
-                        **all_candidates_aux_dict,
-                        **candidates_aux_dict
-                        }
+                    all_candidates_aux_dict = {**all_candidates_aux_dict,
+                                               **candidates_aux_dict}
                     candidates_format.extend(_candidates_format)
             self.write_auxiliary_files(auxiliary_folder,
                                        all_candidates_aux_dict,
@@ -61,12 +54,10 @@ class Utility(object):
                             self.create_candidates, rows,
                             repeat(relevant_columns), repeat(column),
                             repeat(size), repeat(properties), repeat(method),
-                            repeat(lower_case),
-                            repeat(auxiliary_fields), repeat(extra_musts)):
-                    all_candidates_aux_dict = {
-                        **all_candidates_aux_dict,
-                        **candidates_aux_dict
-                        }
+                            repeat(lower_case), repeat(auxiliary_fields),
+                            repeat(extra_musts)):
+                    all_candidates_aux_dict = {**all_candidates_aux_dict,
+                                               **candidates_aux_dict}
                     candidates_format.extend(_candidates_format)
             self.write_auxiliary_files(auxiliary_folder,
                                        all_candidates_aux_dict,
@@ -81,8 +72,7 @@ class Utility(object):
 
     def create_candidates(self, row, relevant_columns, column, size,
                           properties, method, lower_case,
-                          auxiliary_fields=None,
-                          extra_musts=None):
+                          auxiliary_fields=None, extra_musts=None):
         candidates_format = list()
 
         _ = {}
@@ -90,11 +80,8 @@ class Utility(object):
             _[k] = row[k]
 
         candidate_dict, candidate_aux_dict = self.es.search_term_candidates(
-                                            _[column],
-                                            size,
-                                            properties,
-                                            method,
-                                            lower_case=lower_case,
+                                            _[column], size, properties,
+                                            method, lower_case=lower_case,
                                             auxiliary_fields=auxiliary_fields,
                                             extra_musts=extra_musts)
 


### PR DESCRIPTION
Added function create_candidates: To get candidates for a given row (a single record) and return candidates_format and candidates_aux_dict

Modified create_candidates_df: To call create_candidates function using ThreadPoolExecutor for either a candidates file or a canonical file.